### PR TITLE
Remove use of $continue.

### DIFF
--- a/screens custom.rpy
+++ b/screens custom.rpy
@@ -430,13 +430,13 @@ screen battle_screen:
                         if BM.weaponhover == None:
                             $BM.weaponhover = BM.active_weapon
                         if BM.weaponhover.wtype == 'Support' and ship.faction != 'Player':
-                            $continue
-                        if BM.weaponhover.wtype != 'Support' and ship.faction == 'Player':
-                            $continue
-                        if BM.weaponhover.wtype == 'Melee' and (ship.stype != 'Ryder' or get_ship_distance(ship,BM.selected) > 1):
-                            $continue
-                        if BM.weaponhover.name == 'Gravity Gun' and ship.stype != 'Ryder':
-                            $continue
+                            pass
+                        elif BM.weaponhover.wtype != 'Support' and ship.faction == 'Player':
+                            pass
+                        elif BM.weaponhover.wtype == 'Melee' and (ship.stype != 'Ryder' or get_ship_distance(ship,BM.selected) > 1):
+                            pass
+                        elif BM.weaponhover.name == 'Gravity Gun' and ship.stype != 'Ryder':
+                            pass
 
 
                         if ship.location == (a,b):


### PR DESCRIPTION
$continue is not valid screen language code, since there isn't a python for loop here. 

Ren'Py 6.18, which includes a faster reimplementation of screen language, won't be able to process a $continue, as it no longer comples SL directly to Python code. This change will make it possible to run Sunrider under a newer Ren'Py.
