### PR TITLE
fixed a small typo that causes a crash

### DIFF
--- a/functions.rpy
+++ b/functions.rpy
@@ -45,7 +45,7 @@ init -6 python:
         for pending in reversed(BM.pending_upgrades):
             if pending[1] == upgrade:
                 revert = pending
-            break
+                break
         name,level,increase,cost,multiplier = revert[2]
         BM.money += cost
         new_value = getattr(ship,upgrade)-increase


### PR DESCRIPTION
This break should be within the if statement else trying to revert an upgrade that was not the last upgrade added will cause an index out of range error.
