### PR TITLE
Lint errors fix

### DIFF
--- a/ava.rpy
+++ b/ava.rpy
@@ -354,17 +354,20 @@
         xanchor 0.5
         zoom 0.6255
         subpixel True             
-        
-        
-        
-        
-        
+
+    image ava uniform handsonhips neutral:
+        "Character/Ava/ava_uniform_handonhip_neutral.png"
+        yanchor 0.51 ypos 1.0
+        xanchor 0.5
+        zoom 0.6255
+        subpixel True
+
     image ava beach altneutral mad:
         "Character/Ava/ava_beach_altneutral_mad.png"
         yanchor 0.51 ypos 1.0
         xanchor 0.5
         zoom 0.6255
-        subpixel True         
+        subpixel True
     image ava beach handsonhips angry:
         "Character/Ava/ava_beach_handsonhips_angry.png"
         yanchor 0.51 ypos 1.0

--- a/script.rpy
+++ b/script.rpy
@@ -18408,7 +18408,7 @@ label aftermission17:
     fon "So the great Grey of the Emerald Fleet finally speaks. Have you come to discuss terms of surrender?"
     gre "You little punk."
     gre "Don't think you're the first commander to dare raise sword against me. But you're still young."
-    gre "Sit down boy, and let me show you {i}war.{i}"
+    gre "Sit down boy, and let me show you {i}war.{/i}"
     ava "Captain, I'm detecting radiation charges coming from the Combined Fleet!"
     gre "I've just ordered every Alliance ship to arm their nuclear torpedoes at Ongess."
     gre "These are my terms. Tell your little pirate friend to turn around and scurry back to the rat hole she crawled out of."


### PR DESCRIPTION
Next are removed:
game/script.rpy:2632 The image named 'ava uniform handsonhips neutral' was not declared.
game/script.rpy:18411 One or more text tags were left open at the end of the string: 'i', 'i' (in 'Sit down boy, and let me show you {i}war.{i}')

Next errors remain:
game/combatlabels.rpy:118 unable to evaluate filename u'PlayerTurnMusic'

game/graphic inits.rpy:349 Image bg battlegrid uses file 'Gameplay/battlegrid.jpg', which is not loadable.
