### PR TITLE
Add short range warp to orders if you start new campaign directly

### DIFF
--- a/script.rpy
+++ b/script.rpy
@@ -22750,6 +22750,7 @@ label continuewithchoices:
     python:
         BM.money = 19000
         BM.cmd = 4000
+        BM.orders['SHORT RANGE WARP'] = [750,'short_range_warp'] ## Adds in SRW, since the plot event to add it is skipped. Tested it in the current steam ver with and without, should work.
         gal_event = 'jumptogalaxy'
         alliancecruiser1 = None
         alliancecruiser2 = None


### PR DESCRIPTION
Minor, but there you go. Tested it, should work, but I tested it in the current steam ver, not the actual github ver.
