### PR TITLE
Fix dialogue issues with Chigara's introduction

### DIFF
--- a/classes.rpy
+++ b/classes.rpy
@@ -3143,6 +3143,7 @@ init -2 python:
             store.affection_cosette = 0
 
             store.MetAsaga = False
+            store.ChigaraNamed = False
             store.ChigaraRefugee = False
             store.mission_pirateattack = False
             store.amissionforalliance = False

--- a/firstvariables.rpy
+++ b/firstvariables.rpy
@@ -12,6 +12,7 @@ label firstvariables:
     $ affection_cosette = 0
 
     $ MetAsaga = False
+    $ ChigaraNamed = False
     $ ChigaraRefugee = False
     $ mission_pirateattack = False
     $ amissionforalliance = False
@@ -107,6 +108,7 @@ init python:
             self.affection_cosette = 0
 
             self.MetAsaga = False
+            self.ChigaraNamed = False
             self.ChigaraRefugee = False
             self.mission_pirateattack = False
             self.amissionforalliance = False

--- a/script.rpy
+++ b/script.rpy
@@ -1595,6 +1595,7 @@ label tellmorefreelancing:
     kay " Chigara...? Is she an engineer?"
     asa " Yeah, you can call her that. She's a genius when it comes to technology, and she can fix just about anything mechanical!"
     kay "(I'm betting we'll get to meet this Chigara very soon...)"
+    $ ChigaraNamed = True
 
     menu:
         "Tell me more about the pirates.":
@@ -1704,9 +1705,13 @@ label fornowsunriderrepairs:
 
     show asaga plugsuit handsonhips happy with dissolve
 
-    asa "Oh! I know someone who can help us with that! Chigara has her workshop in Tydaria. She'll be able to fix your ship in no time!"
-    ava "Chigara? Friend of yours?"
-    asa "Uh-huh! She's a genius when it comes to technology!"
+    if ChigaraNamed:
+        asa "Oh! Chigara has her workshop in Tydaria. She'll be able to fix your ship in no time!"
+    else:
+        asa "Oh! I know someone who can help us with that! Chigara has her workshop in Tydaria. She'll be able to fix your ship in no time!"
+        ava "Chigara? Friend of yours?"
+        asa "Uh-huh! She's a genius when it comes to technology!"
+        
     kay "Alright, if your friend can help us, we can head to her workshop."
     kay "Ava and I are going to head up to the bridge now. You should stay here with your ship. We'll call you on the comm if anything comes up."
     asa "Understood, capt'n!"


### PR DESCRIPTION
- Before, Asaga would namedrop Chigara and then explain who she is twice: once during the menu dialogue option (asking Asaga about her freelance work), and once (mandatory) when Kayto states his intention to dock at Tydaria  for repairs. Now she only does it on the second occasion if you skip the first one.
- Chigara actually gives her full name when she says she does ("Chigara Lynn Ashada" instead of just "Chigara Lynn").
